### PR TITLE
use the BufReader to consume all bytes

### DIFF
--- a/axess_core/src/transport/serial.rs
+++ b/axess_core/src/transport/serial.rs
@@ -123,9 +123,9 @@ impl Transport for TransportSerial {
             let port = port.try_clone()?;
             let stop = stop.clone();
             std::thread::spawn(move || {
-                let mut buffered_reader = BufReader::new(port);
-                let mut buffer = vec![];
+                let mut buffered_reader = BufReader::new(port);                
                 loop {
+                    let mut buffer = vec![];
                     match buffered_reader.read_until(SYSEX_END, &mut buffer) {
                         Ok(bytes) => {
                             let buffer = &buffer[0..bytes];


### PR DESCRIPTION
FM3 messages should always end with a SYSEX_END character, so we can keep blocking the serial read until the buffer fills up with that character.